### PR TITLE
fix: sleep before checking exposed ports

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	dockerapi "github.com/fsouza/go-dockerclient"
 )
@@ -51,6 +52,10 @@ func (b *Bridge) Ping() error {
 }
 
 func (b *Bridge) Add(containerId string) {
+	// Give Docker more time to assign host ports for the container's ephemeral ports. Without this
+	// sleep, an ephemeral port may be ignored if Docker hasn't finished assigning a host port yet
+	time.Sleep(1 * time.Second)
+
 	b.Lock()
 	defer b.Unlock()
 	b.add(containerId, false)


### PR DESCRIPTION
## Description

- Rise folks (and probably others?) have been experiencing a problem with skipper where services are incorrectly ignored by registrator, preventing fabio from routing dev URLs to locally running services
- The problem is flaky and random. It doesn't happen on every service start, but when it does happen, it tends to happen more than once. Our current workaround is to stop and restart services repeatedly until fabio indicates that the dev URLs are routed to local containers
- I think this is due to a race condition. Registrator ignores exposed service ports that don't have an assigned host port, but it appears that host ports aren't always assigned right away after a container is started: There's an apparent delay when assigning [ephemeral ports](https://docs.docker.com/get-started/docker-concepts/running-containers/publishing-ports/#publishing-to-ephemeral-ports) to services, but no delay when assigning static ports. (In Rise, our main services [use ephemeral ports](https://github.com/articulate/rise-runtime/blob/master/docker-compose.yml#L16).) Whenever registrator checks an exposed ephemeral port before its host port has been assigned, it'll ignore that port and won't check/sync it again even after the host port is assigned
- Having registrator sleep for 1 second after a container is `Add`ed but before checking exposed ports seems to give Docker enough time to finish port assignment, mitigating the problem
- Another way we've been able to prevent the issue is assigning a static port to exposed ports in our docker compose files, but this isn't an ideal fix since we'd need to avoid ports that conflict with other services

## Status

Some members of rise-authoring-core have tested this PR over 4-ish days to see if it fixes the problem consistently. For people who didn't test, they were still experiencing the problem with skipper/registrator, requiring repeated service restarts. For folks who did test, they didn't experience the problem and didn't need to restart their services. It seems like the sleep solution works

## Demonstrating the problem

The debug code for this was removed, but you can see it in [this commit](https://github.com/articulate/docker-registrator/commit/0ac5a84455ea14103bb9e151f68a958721a5ab61)

1. With this branch checked out, comment out the `time.Sleep` line 56 of `bridge/bridge.go`
2. From the root of the repo, run this command to replace your local registrator image:
   ```sh
   docker build -t articulate/docker-registrator:latest .
   ```
   (It can take a few minutes. My average wait time is ~190s)
3. Start skipper in a new terminal:
   ```sh
   art skipper up
   ```
4. In a separate terminal, start [rise-runtime](https://github.com/articulate/rise-runtime) (remember to complete the [setup steps](https://github.com/articulate/rise-runtime?tab=readme-ov-file#getting-started) if you haven't already):
   ```sh
   cd ~/path/to/rise-runtime && art --on 360-stage docker compose up
   ```
5. Watch the skipper logs while looking for the string `!!! RISE RUNTIME FAILED TO REGISTER !!!`. If you don't see the string and fabio adds the runtime routes successfully (indicated by `+ route add rise-runtime ...` logs), stop and restart runtime until you do see the string
6. When that string prints, fabio won't add the local runtime routes. Whenever this happens, the only recourse is to restart runtime repeatedly until it doesn't happen

## Testing the sleep solution

1. Stash your changes from the previous section, if any
2. From the root of the repo, run this command to replace your local registrator image:
   ```sh
   docker build -t articulate/docker-registrator:latest .
   ```
7. Start skipper:
   ```sh
   art skipper up
   ```
8. Go about your work day. If you don't encounter any issues with skipper/fabio routing traffic to local services, that means it's working

## Cleanup

1. Pull the original registrator image to cleanup any changes you made during testing:
   ```sh
   docker pull articulate/docker-registrator:latest
   ```